### PR TITLE
@log_post.body in show.html.erb now renders html

### DIFF
--- a/app/views/log_posts/show.html.erb
+++ b/app/views/log_posts/show.html.erb
@@ -11,7 +11,7 @@
 
   <p>
     <strong>Body:</strong>
-    <%= @log_post.body %>
+    <%= @log_post.body.html_safe %>
   </p>
 
   <p>


### PR DESCRIPTION
## Changes
- @log_post.body in show.html.erb was rendering html tags from the WSIWIG.  It now renders the html properly by adding the .html_safe method
